### PR TITLE
fix: change API key header from Authorization Bearer to x-api-key

### DIFF
--- a/docs/docs/architecture/authentication.mdx
+++ b/docs/docs/architecture/authentication.mdx
@@ -14,22 +14,13 @@ The primary authentication method for programmatic access to the Mesh API.
 
 **Header Format:**
 ```
-Authorization: Bearer {api_key}
+x-api-key: {api_key}
 x-group: groups/{group_ulid}
 ```
 
 **Key Characteristics:**
-- API keys are generated when creating API users
-- Each API key belongs to a specific group context
-- API keys can be activated or deactivated for access control
-- Bearer token format for standard HTTP authorization
-
-**Example:**
-```bash
-curl -H "Authorization: Bearer mesh_12345abcdef..." \
-     -H "x-group: groups/{group_ulid}" \
-     https://api.mesh.dev/iam/api_user/v1/api_users
-```
+API keys are generated when creating API users.
+- See **[Introduction](/docs/architecture/group-ownership)** or **[IAM API User Service Reference](/docs/api-reference/iam/api_user/v1)** for more.
 
 ### Group Context
 

--- a/go/auth/constants.go
+++ b/go/auth/constants.go
@@ -2,7 +2,6 @@ package auth
 
 // gRPC metadata constants for authentication
 const (
-	AuthorizationHeaderKey = "authorization"
-	GroupHeaderKey         = "x-group"
-	BearerPrefix           = "Bearer "
+	APIKeyHeader   = "x-api-key"
+	GroupHeaderKey = "x-group"
 )

--- a/go/grpc/client.go
+++ b/go/grpc/client.go
@@ -433,8 +433,8 @@ func (b *BaseGRPCClient[T]) authInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		ctx = metadata.AppendToOutgoingContext(
 			ctx,
-			auth.AuthorizationHeaderKey,
-			auth.BearerPrefix+b.apiKey,
+			auth.APIKeyHeader,
+			b.apiKey,
 			auth.GroupHeaderKey,
 			b.group,
 		)

--- a/go/grpc/config/options.go
+++ b/go/grpc/config/options.go
@@ -102,14 +102,14 @@ func WithPort(port int) ServiceOption {
 }
 
 // WithAPIKey configures API key authentication for the gRPC service.
-// The API key will be sent as a Bearer token in the Authorization header.
+// The API key will be sent in the x-api-key header.
 // This is the primary authentication method for service-to-service communication.
 //
 // IMPORTANT: When using API key authentication, you must also specify a group
 // using WithGroup() or load from credentials file via MESH_API_CREDENTIALS.
 //
 // Parameter:
-//   - apiKey: The API key string (without "Bearer " prefix)
+//   - apiKey: The API key string
 //
 // Example:
 //

--- a/go/iam/api_user/v1/api_credentials.pb.go
+++ b/go/iam/api_user/v1/api_credentials.pb.go
@@ -30,7 +30,7 @@ const (
 // is the unique identifier of the owning group.
 type APICredentials struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The API key used for Bearer token authentication.
+	// The API key used for x-api-key header authentication.
 	// This should be kept secure and never exposed in logs or version control.
 	// Required field.
 	ApiKey string `protobuf:"bytes,1,opt,name=api_key,json=apiKey,proto3" json:"api_key,omitempty"`

--- a/java/src/main/java/co/meshtrade/api/auth/Credentials.java
+++ b/java/src/main/java/co/meshtrade/api/auth/Credentials.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * with Meshtrade services. Both fields are required and are used to generate
  * the appropriate authentication headers for gRPC requests.
  * 
- * <p>The API key is used for Bearer token authentication, while the group ID
+ * <p>The API key is used for x-api-key header authentication, while the group ID
  * specifies the organizational context for API operations and resource scoping.
  * 
  * <h2>Example</h2>
@@ -20,7 +20,7 @@ import java.util.Objects;
  * String group = creds.group();       // "groups/your-group-id"
  * }</pre>
  * 
- * @param apiKey the API key for Bearer token authentication (43 characters, base64 URL-safe)
+ * @param apiKey the API key for x-api-key header authentication (43 characters, base64 URL-safe)
  * @param group the group resource name in format "groups/{group_id}"
  * 
  * @see CredentialsDiscovery
@@ -31,7 +31,7 @@ public record Credentials(String apiKey, String group) {
     /**
      * Creates a new Credentials instance with validation.
      * 
-     * @param apiKey the API key for Bearer token authentication
+     * @param apiKey the API key for x-api-key header authentication
      * @param group the group resource name
      * @throws NullPointerException if either parameter is null
      * @throws IllegalArgumentException if either parameter is empty or invalid
@@ -74,10 +74,10 @@ public record Credentials(String apiKey, String group) {
     }
     
     /**
-     * Returns the API key for Bearer token authentication.
+     * Returns the API key for x-api-key header authentication.
      * 
-     * <p>This key should be included in the Authorization header as:
-     * {@code Authorization: Bearer {apiKey}}
+     * <p>This key should be included in the x-api-key header as:
+     * {@code x-api-key: {apiKey}}
      * 
      * @return the API key (43 characters, base64 URL-safe encoded)
      */

--- a/java/src/main/java/co/meshtrade/api/grpc/BaseGRPCClient.java
+++ b/java/src/main/java/co/meshtrade/api/grpc/BaseGRPCClient.java
@@ -42,8 +42,8 @@ import java.util.function.Function;
  * 
  * <h2>Authentication</h2>
  * <p>Authentication is handled automatically using the API key and group from
- * {@link ServiceOptions}. The API key is sent in the Authorization header as a
- * Bearer token, while the group is sent in the x-group header.
+ * {@link ServiceOptions}. The API key is sent in the x-api-key header,
+ * while the group is sent in the x-group header.
  * 
  * <h2>Resource Management</h2>
  * <p>This class implements {@link AutoCloseable} to ensure proper cleanup of
@@ -76,7 +76,7 @@ public abstract class BaseGRPCClient<T extends AbstractStub<T>> implements AutoC
     private static final Logger logger = LoggerFactory.getLogger(BaseGRPCClient.class);
     
     private static final Metadata.Key<String> API_KEY_HEADER = 
-        Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key.of("x-api-key", Metadata.ASCII_STRING_MARSHALLER);
     private static final Metadata.Key<String> GROUP_HEADER = 
         Metadata.Key.of("x-group", Metadata.ASCII_STRING_MARSHALLER);
     
@@ -335,7 +335,7 @@ public abstract class BaseGRPCClient<T extends AbstractStub<T>> implements AutoC
             public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
                 try {
                     Metadata headers = new Metadata();
-                    headers.put(API_KEY_HEADER, "Bearer " + options.getApiKey());
+                    headers.put(API_KEY_HEADER, options.getApiKey());
                     headers.put(GROUP_HEADER, options.getGroup());
                     applier.apply(headers);
                 } catch (Exception e) {

--- a/java/src/main/java/co/meshtrade/api/iam/api_user/v1/ApiCredentials.java
+++ b/java/src/main/java/co/meshtrade/api/iam/api_user/v1/ApiCredentials.java
@@ -33,7 +33,7 @@ public final class ApiCredentials {
     /**
      * <pre>
      *
-     * The API key used for Bearer token authentication.
+     * The API key used for x-api-key header authentication.
      * This should be kept secure and never exposed in logs or version control.
      * Required field.
      * </pre>
@@ -45,7 +45,7 @@ public final class ApiCredentials {
     /**
      * <pre>
      *
-     * The API key used for Bearer token authentication.
+     * The API key used for x-api-key header authentication.
      * This should be kept secure and never exposed in logs or version control.
      * Required field.
      * </pre>
@@ -139,7 +139,7 @@ public final class ApiCredentials {
     /**
      * <pre>
      *
-     * The API key used for Bearer token authentication.
+     * The API key used for x-api-key header authentication.
      * This should be kept secure and never exposed in logs or version control.
      * Required field.
      * </pre>
@@ -163,7 +163,7 @@ public final class ApiCredentials {
     /**
      * <pre>
      *
-     * The API key used for Bearer token authentication.
+     * The API key used for x-api-key header authentication.
      * This should be kept secure and never exposed in logs or version control.
      * Required field.
      * </pre>
@@ -573,7 +573,7 @@ public final class ApiCredentials {
       /**
        * <pre>
        *
-       * The API key used for Bearer token authentication.
+       * The API key used for x-api-key header authentication.
        * This should be kept secure and never exposed in logs or version control.
        * Required field.
        * </pre>
@@ -596,7 +596,7 @@ public final class ApiCredentials {
       /**
        * <pre>
        *
-       * The API key used for Bearer token authentication.
+       * The API key used for x-api-key header authentication.
        * This should be kept secure and never exposed in logs or version control.
        * Required field.
        * </pre>
@@ -620,7 +620,7 @@ public final class ApiCredentials {
       /**
        * <pre>
        *
-       * The API key used for Bearer token authentication.
+       * The API key used for x-api-key header authentication.
        * This should be kept secure and never exposed in logs or version control.
        * Required field.
        * </pre>
@@ -640,7 +640,7 @@ public final class ApiCredentials {
       /**
        * <pre>
        *
-       * The API key used for Bearer token authentication.
+       * The API key used for x-api-key header authentication.
        * This should be kept secure and never exposed in logs or version control.
        * Required field.
        * </pre>
@@ -657,7 +657,7 @@ public final class ApiCredentials {
       /**
        * <pre>
        *
-       * The API key used for Bearer token authentication.
+       * The API key used for x-api-key header authentication.
        * This should be kept secure and never exposed in logs or version control.
        * Required field.
        * </pre>

--- a/proto/meshtrade/iam/api_user/v1/api_credentials.proto
+++ b/proto/meshtrade/iam/api_user/v1/api_credentials.proto
@@ -17,7 +17,7 @@ option java_package = "co.meshtrade.api.iam.api_user.v1";
 */
 message APICredentials {
   /*
-     The API key used for Bearer token authentication.
+     The API key used for x-api-key header authentication.
      This should be kept secure and never exposed in logs or version control.
      Required field.
   */

--- a/python/src/meshtrade/common/__init__.py
+++ b/python/src/meshtrade/common/__init__.py
@@ -2,8 +2,7 @@
 
 from .config import (
     ACCESS_TOKEN_PREFIX,
-    AUTHORIZATION_HEADER_KEY,
-    BEARER_PREFIX,
+    API_KEY_HEADER,
     COOKIE_HEADER_KEY,
     DEFAULT_GRPC_PORT,
     DEFAULT_GRPC_URL,
@@ -17,10 +16,9 @@ __all__ = [
     "DEFAULT_GRPC_URL",
     "DEFAULT_GRPC_PORT",
     "DEFAULT_TLS",
-    "AUTHORIZATION_HEADER_KEY",
+    "API_KEY_HEADER",
     "COOKIE_HEADER_KEY",
     "GROUP_HEADER_KEY",
-    "BEARER_PREFIX",
     "ACCESS_TOKEN_PREFIX",
     "create_auth_metadata",
     "GRPCClient",

--- a/python/src/meshtrade/common/config.py
+++ b/python/src/meshtrade/common/config.py
@@ -7,10 +7,9 @@ DEFAULT_GRPC_PORT = 443
 DEFAULT_TLS = True
 
 # gRPC metadata constants
-AUTHORIZATION_HEADER_KEY = "authorization"
+API_KEY_HEADER = "x-api-key"
 COOKIE_HEADER_KEY = "cookie"
 GROUP_HEADER_KEY = "x-group"
-BEARER_PREFIX = "Bearer "
 ACCESS_TOKEN_PREFIX = "AccessToken="
 
 
@@ -18,13 +17,13 @@ def create_auth_metadata(api_key: str, group: str) -> list[tuple[str, str]]:
     """Create authentication metadata for gRPC requests.
 
     Args:
-        api_key: The API key (without Bearer prefix)
+        api_key: The API key
         group: The group resource name in format groups/{group_id}
 
     Returns:
         List of metadata header tuples for authentication
     """
     return [
-        (AUTHORIZATION_HEADER_KEY, f"{BEARER_PREFIX}{api_key}"),
+        (API_KEY_HEADER, api_key),
         (GROUP_HEADER_KEY, group),  # Send full groups/uuid format in header
     ]


### PR DESCRIPTION
Updates all SDKs to use x-api-key header instead of Authorization: Bearer {token}
format for API authentication, providing cleaner and more standard API key usage.

Changes across all SDKs:
- Go: Update auth constants and client interceptor
- Python: Replace AUTHORIZATION_HEADER_KEY with API_KEY_HEADER
- Java: Update BaseGRPCClient and Credentials class
- Protobuf: Update api_credentials.proto comment
- Documentation: Update authentication.mdx with new header format

All generated code regenerated from updated protobuf definitions.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>