### PR TITLE
Add owner filter to SearchAccountsRequest

### DIFF
--- a/go/wallet/account/v1/service.pb.go
+++ b/go/wallet/account/v1/service.pb.go
@@ -652,8 +652,14 @@ type SearchAccountsRequest struct {
 	// When true, fetches current balances and state from the ledger.
 	// When false, returns only stored metadata without live data.
 	PopulateLedgerData bool `protobuf:"varint,3,opt,name=populate_ledger_data,json=populateLedgerData,proto3" json:"populate_ledger_data,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Optional filter by direct owner group.
+	// Filters on the account's 'owner' field (the immediate parent group),
+	// not the 'owners' hierarchy. Only accounts whose direct owner matches
+	// one of the provided groups are returned.
+	// Format: groups/{ULIDv2}.
+	Owner         []string `protobuf:"bytes,4,rep,name=owner,proto3" json:"owner,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SearchAccountsRequest) Reset() {
@@ -705,6 +711,13 @@ func (x *SearchAccountsRequest) GetPopulateLedgerData() bool {
 		return x.PopulateLedgerData
 	}
 	return false
+}
+
+func (x *SearchAccountsRequest) GetOwner() []string {
+	if x != nil {
+		return x.Owner
+	}
+	return nil
 }
 
 // Response containing search results.
@@ -1115,12 +1128,14 @@ const file_meshtrade_wallet_account_v1_service_proto_rawDesc = "" +
 	"R\x00R\x06numberR\x05field\x125\n" +
 	"\x05order\x18\x02 \x01(\x0e2\x1f.meshtrade.type.v1.SortingOrderR\x05order\"X\n" +
 	"\x14ListAccountsResponse\x12@\n" +
-	"\baccounts\x18\x01 \x03(\v2$.meshtrade.wallet.account.v1.AccountR\baccounts\"\xef\x03\n" +
+	"\baccounts\x18\x01 \x03(\v2$.meshtrade.wallet.account.v1.AccountR\baccounts\"\xc7\x04\n" +
 	"\x15SearchAccountsRequest\x12T\n" +
 	"\asorting\x18\x01 \x01(\v2:.meshtrade.wallet.account.v1.SearchAccountsRequest.SortingR\asorting\x12\x93\x01\n" +
 	"\fdisplay_name\x18\x02 \x01(\tBp\xbaHm\xba\x01e\n" +
 	"\x17display_name.max_length\x127display_name search term must not exceed 255 characters\x1a\x11size(this) <= 255r\x03\x18\xff\x01R\vdisplayName\x120\n" +
-	"\x14populate_ledger_data\x18\x03 \x01(\bR\x12populateLedgerData\x1a\xb7\x01\n" +
+	"\x14populate_ledger_data\x18\x03 \x01(\bR\x12populateLedgerData\x12V\n" +
+	"\x05owner\x18\x04 \x03(\tB@\xbaH=\x92\x01:\x10\n" +
+	"\"6r42/^groups/[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$\x98\x01!R\x05owner\x1a\xb7\x01\n" +
 	"\aSorting\x12u\n" +
 	"\x05field\x18\x01 \x01(\tB_\xbaH\\\xba\x01M\n" +
 	"\vfield.valid\x12&field must be one of: number, or empty\x1a\x16this in ['', 'number']r\n" +

--- a/proto/meshtrade/wallet/account/v1/service.proto
+++ b/proto/meshtrade/wallet/account/v1/service.proto
@@ -529,6 +529,25 @@ message SearchAccountsRequest {
      When false, returns only stored metadata without live data.
   */
   bool populate_ledger_data = 3;
+
+  /*
+     Optional filter by direct owner group.
+     Filters on the account's 'owner' field (the immediate parent group),
+     not the 'owners' hierarchy. Only accounts whose direct owner matches
+     one of the provided groups are returned.
+     Format: groups/{ULIDv2}.
+  */
+  repeated string owner = 4 [(buf.validate.field) = {
+    repeated: {
+      max_items: 10
+      items: {
+        string: {
+          len: 33
+          pattern: "^groups/[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
+        }
+      }
+    }
+  }];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adds a repeated `owner` field to `SearchAccountsRequest` for filtering accounts by their direct owner group (`account.owner`), not the hierarchical `owners` list
- Includes buf validation: max 10 items, each matching `groups/{ULIDv2}` format
- Includes generated Go protobuf code

## Test plan
- [x] Run `buf lint` to validate protobuf changes
- [x] Run `./dev/tool.sh all` to regenerate all SDK bindings
- [x] Verify backend handles the new filter field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)