### PR TITLE
Extend instrument types and add ownership certificate field

### DIFF
--- a/go/studio/instrument/v1/instrument_type.pb.go
+++ b/go/studio/instrument/v1/instrument_type.pb.go
@@ -30,26 +30,27 @@ const (
 	// Unknown or not specified.
 	// This is a default value to prevent accidental assignment and should not be used.
 	InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED InstrumentType = 0
-	// Other or unlisted instrument type.
+	// Unknown/Uncategorised Instrument Type.
 	InstrumentType_INSTRUMENT_TYPE_OTHER InstrumentType = 1
-	// Equity share.
+	// Equity Share.
 	InstrumentType_INSTRUMENT_TYPE_SHARE InstrumentType = 2
-	// Preference share.
+	// Preference Share.
 	InstrumentType_INSTRUMENT_TYPE_PREFERENCE_SHARE InstrumentType = 3
 	// Bond.
 	InstrumentType_INSTRUMENT_TYPE_BOND InstrumentType = 4
-	// Exchange-traded fund.
+	// Exchange Traded Fund
 	InstrumentType_INSTRUMENT_TYPE_ETF InstrumentType = 5
-	// Exchange-traded note.
+	// Exchange Traded Note.
 	InstrumentType_INSTRUMENT_TYPE_ETN InstrumentType = 6
-	// Actively managed certificate.
+	// Actively Managed Certificate.
 	InstrumentType_INSTRUMENT_TYPE_AMC InstrumentType = 7
-	// Unit trust.
+	// Unit Trust.
 	InstrumentType_INSTRUMENT_TYPE_UNIT_TRUST InstrumentType = 8
-	// Cryptocurrency.
+	// Cryptocurrency
 	InstrumentType_INSTRUMENT_TYPE_CRYPTO_CURRENCY InstrumentType = 9
-	// Fiat currency.
+	// Fiat currency (non-blockchain ledgers)
 	InstrumentType_INSTRUMENT_TYPE_FIAT_CURRENCY InstrumentType = 10
+	// 11 no longer used
 	// Gold.
 	InstrumentType_INSTRUMENT_TYPE_GOLD InstrumentType = 12
 	// Silver.
@@ -70,26 +71,33 @@ const (
 	InstrumentType_INSTRUMENT_TYPE_WHEAT InstrumentType = 20
 	// Soybeans.
 	InstrumentType_INSTRUMENT_TYPE_SOYBEANS InstrumentType = 21
-	// Fiat-backed stablecoin.
-	InstrumentType_INSTRUMENT_TYPE_FIAT_STABLECOIN InstrumentType = 22
-	// Money market fund.
+	// 22 no longer used
+	// Blockchain Native Money market fund.
 	InstrumentType_INSTRUMENT_TYPE_MONEY_MARKET_FUND InstrumentType = 23
-	// Tokenised money market fund.
+	// Tokenised Money market fund.
 	InstrumentType_INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN InstrumentType = 24
 	// Endowment wrapper.
 	InstrumentType_INSTRUMENT_TYPE_ENDOWMENT_WRAPPER InstrumentType = 25
-	// Fund.
+	// Blockchain Native Fund.
 	InstrumentType_INSTRUMENT_TYPE_FUND InstrumentType = 26
-	// Tokenised fund.
+	// Tokenised Fund.
 	InstrumentType_INSTRUMENT_TYPE_FUND_STABLECOIN InstrumentType = 27
-	// Tokenised actively managed certificate.
+	// Tokenised AMC.
 	InstrumentType_INSTRUMENT_TYPE_AMC_STABLECOIN InstrumentType = 28
 	// Tokenised exchange-traded fund.
 	InstrumentType_INSTRUMENT_TYPE_ETF_STABLECOIN InstrumentType = 29
 	// Tokenised exchange-traded note.
 	InstrumentType_INSTRUMENT_TYPE_ETN_STABLECOIN InstrumentType = 30
-	// Tokenised cryptocurrency.
+	// Wrapped cryptocurrency.
 	InstrumentType_INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN InstrumentType = 31
+	// Stablecoin, i.e. tokenised fiat currency.
+	InstrumentType_INSTRUMENT_TYPE_FIAT_CURRENCY_STABLECOIN InstrumentType = 32
+	// Wrapped Cryptocurrency with yield.
+	InstrumentType_INSTRUMENT_TYPE_YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN InstrumentType = 33
+	// Fiat Currency Stablecoin with yield.
+	InstrumentType_INSTRUMENT_TYPE_YIELD_BEARING_FIAT_CURRENCY_STABLECOIN InstrumentType = 34
+	// Share in a liquidity pool share
+	InstrumentType_INSTRUMENT_TYPE_LIQUIDITY_POOL_SHARE InstrumentType = 35
 )
 
 // Enum value maps for InstrumentType.
@@ -116,7 +124,6 @@ var (
 		19: "INSTRUMENT_TYPE_CORN",
 		20: "INSTRUMENT_TYPE_WHEAT",
 		21: "INSTRUMENT_TYPE_SOYBEANS",
-		22: "INSTRUMENT_TYPE_FIAT_STABLECOIN",
 		23: "INSTRUMENT_TYPE_MONEY_MARKET_FUND",
 		24: "INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN",
 		25: "INSTRUMENT_TYPE_ENDOWMENT_WRAPPER",
@@ -126,39 +133,46 @@ var (
 		29: "INSTRUMENT_TYPE_ETF_STABLECOIN",
 		30: "INSTRUMENT_TYPE_ETN_STABLECOIN",
 		31: "INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN",
+		32: "INSTRUMENT_TYPE_FIAT_CURRENCY_STABLECOIN",
+		33: "INSTRUMENT_TYPE_YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN",
+		34: "INSTRUMENT_TYPE_YIELD_BEARING_FIAT_CURRENCY_STABLECOIN",
+		35: "INSTRUMENT_TYPE_LIQUIDITY_POOL_SHARE",
 	}
 	InstrumentType_value = map[string]int32{
-		"INSTRUMENT_TYPE_UNSPECIFIED":                  0,
-		"INSTRUMENT_TYPE_OTHER":                        1,
-		"INSTRUMENT_TYPE_SHARE":                        2,
-		"INSTRUMENT_TYPE_PREFERENCE_SHARE":             3,
-		"INSTRUMENT_TYPE_BOND":                         4,
-		"INSTRUMENT_TYPE_ETF":                          5,
-		"INSTRUMENT_TYPE_ETN":                          6,
-		"INSTRUMENT_TYPE_AMC":                          7,
-		"INSTRUMENT_TYPE_UNIT_TRUST":                   8,
-		"INSTRUMENT_TYPE_CRYPTO_CURRENCY":              9,
-		"INSTRUMENT_TYPE_FIAT_CURRENCY":                10,
-		"INSTRUMENT_TYPE_GOLD":                         12,
-		"INSTRUMENT_TYPE_SILVER":                       13,
-		"INSTRUMENT_TYPE_PLATINUM":                     14,
-		"INSTRUMENT_TYPE_PALLADIUM":                    15,
-		"INSTRUMENT_TYPE_CRUDE_OIL":                    16,
-		"INSTRUMENT_TYPE_NATURAL_GAS":                  17,
-		"INSTRUMENT_TYPE_COPPER":                       18,
-		"INSTRUMENT_TYPE_CORN":                         19,
-		"INSTRUMENT_TYPE_WHEAT":                        20,
-		"INSTRUMENT_TYPE_SOYBEANS":                     21,
-		"INSTRUMENT_TYPE_FIAT_STABLECOIN":              22,
-		"INSTRUMENT_TYPE_MONEY_MARKET_FUND":            23,
-		"INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN": 24,
-		"INSTRUMENT_TYPE_ENDOWMENT_WRAPPER":            25,
-		"INSTRUMENT_TYPE_FUND":                         26,
-		"INSTRUMENT_TYPE_FUND_STABLECOIN":              27,
-		"INSTRUMENT_TYPE_AMC_STABLECOIN":               28,
-		"INSTRUMENT_TYPE_ETF_STABLECOIN":               29,
-		"INSTRUMENT_TYPE_ETN_STABLECOIN":               30,
-		"INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN":   31,
+		"INSTRUMENT_TYPE_UNSPECIFIED":                              0,
+		"INSTRUMENT_TYPE_OTHER":                                    1,
+		"INSTRUMENT_TYPE_SHARE":                                    2,
+		"INSTRUMENT_TYPE_PREFERENCE_SHARE":                         3,
+		"INSTRUMENT_TYPE_BOND":                                     4,
+		"INSTRUMENT_TYPE_ETF":                                      5,
+		"INSTRUMENT_TYPE_ETN":                                      6,
+		"INSTRUMENT_TYPE_AMC":                                      7,
+		"INSTRUMENT_TYPE_UNIT_TRUST":                               8,
+		"INSTRUMENT_TYPE_CRYPTO_CURRENCY":                          9,
+		"INSTRUMENT_TYPE_FIAT_CURRENCY":                            10,
+		"INSTRUMENT_TYPE_GOLD":                                     12,
+		"INSTRUMENT_TYPE_SILVER":                                   13,
+		"INSTRUMENT_TYPE_PLATINUM":                                 14,
+		"INSTRUMENT_TYPE_PALLADIUM":                                15,
+		"INSTRUMENT_TYPE_CRUDE_OIL":                                16,
+		"INSTRUMENT_TYPE_NATURAL_GAS":                              17,
+		"INSTRUMENT_TYPE_COPPER":                                   18,
+		"INSTRUMENT_TYPE_CORN":                                     19,
+		"INSTRUMENT_TYPE_WHEAT":                                    20,
+		"INSTRUMENT_TYPE_SOYBEANS":                                 21,
+		"INSTRUMENT_TYPE_MONEY_MARKET_FUND":                        23,
+		"INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN":             24,
+		"INSTRUMENT_TYPE_ENDOWMENT_WRAPPER":                        25,
+		"INSTRUMENT_TYPE_FUND":                                     26,
+		"INSTRUMENT_TYPE_FUND_STABLECOIN":                          27,
+		"INSTRUMENT_TYPE_AMC_STABLECOIN":                           28,
+		"INSTRUMENT_TYPE_ETF_STABLECOIN":                           29,
+		"INSTRUMENT_TYPE_ETN_STABLECOIN":                           30,
+		"INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN":               31,
+		"INSTRUMENT_TYPE_FIAT_CURRENCY_STABLECOIN":                 32,
+		"INSTRUMENT_TYPE_YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN": 33,
+		"INSTRUMENT_TYPE_YIELD_BEARING_FIAT_CURRENCY_STABLECOIN":   34,
+		"INSTRUMENT_TYPE_LIQUIDITY_POOL_SHARE":                     35,
 	}
 )
 
@@ -193,7 +207,7 @@ var File_meshtrade_studio_instrument_v1_instrument_type_proto protoreflect.FileD
 
 const file_meshtrade_studio_instrument_v1_instrument_type_proto_rawDesc = "" +
 	"\n" +
-	"4meshtrade/studio/instrument/v1/instrument_type.proto\x12\x1emeshtrade.studio.instrument.v1*\xfc\a\n" +
+	"4meshtrade/studio/instrument/v1/instrument_type.proto\x12\x1emeshtrade.studio.instrument.v1*\xa9\t\n" +
 	"\x0eInstrumentType\x12\x1f\n" +
 	"\x1bINSTRUMENT_TYPE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15INSTRUMENT_TYPE_OTHER\x10\x01\x12\x19\n" +
@@ -216,8 +230,7 @@ const file_meshtrade_studio_instrument_v1_instrument_type_proto_rawDesc = "" +
 	"\x16INSTRUMENT_TYPE_COPPER\x10\x12\x12\x18\n" +
 	"\x14INSTRUMENT_TYPE_CORN\x10\x13\x12\x19\n" +
 	"\x15INSTRUMENT_TYPE_WHEAT\x10\x14\x12\x1c\n" +
-	"\x18INSTRUMENT_TYPE_SOYBEANS\x10\x15\x12#\n" +
-	"\x1fINSTRUMENT_TYPE_FIAT_STABLECOIN\x10\x16\x12%\n" +
+	"\x18INSTRUMENT_TYPE_SOYBEANS\x10\x15\x12%\n" +
 	"!INSTRUMENT_TYPE_MONEY_MARKET_FUND\x10\x17\x120\n" +
 	",INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN\x10\x18\x12%\n" +
 	"!INSTRUMENT_TYPE_ENDOWMENT_WRAPPER\x10\x19\x12\x18\n" +
@@ -226,7 +239,11 @@ const file_meshtrade_studio_instrument_v1_instrument_type_proto_rawDesc = "" +
 	"\x1eINSTRUMENT_TYPE_AMC_STABLECOIN\x10\x1c\x12\"\n" +
 	"\x1eINSTRUMENT_TYPE_ETF_STABLECOIN\x10\x1d\x12\"\n" +
 	"\x1eINSTRUMENT_TYPE_ETN_STABLECOIN\x10\x1e\x12.\n" +
-	"*INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN\x10\x1fBg\n" +
+	"*INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN\x10\x1f\x12,\n" +
+	"(INSTRUMENT_TYPE_FIAT_CURRENCY_STABLECOIN\x10 \x12<\n" +
+	"8INSTRUMENT_TYPE_YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN\x10!\x12:\n" +
+	"6INSTRUMENT_TYPE_YIELD_BEARING_FIAT_CURRENCY_STABLECOIN\x10\"\x12(\n" +
+	"$INSTRUMENT_TYPE_LIQUIDITY_POOL_SHARE\x10#Bg\n" +
 	"%co.meshtrade.api.studio.instrument.v1Z>github.com/meshtrade/api/go/studio/instrument/v1;instrument_v1b\x06proto3"
 
 var (

--- a/go/wallet/account/v1/account.pb.go
+++ b/go/wallet/account/v1/account.pb.go
@@ -260,9 +260,11 @@ type InstrumentMetaData struct {
 	Type v11.InstrumentType `protobuf:"varint,2,opt,name=type,proto3,enum=meshtrade.studio.instrument.v1.InstrumentType" json:"type,omitempty"`
 	// Standard unit of measurement for quantifying the instrument.
 	// Examples: SHARE for equities, OUNCE for precious metals, NOTE for bonds.
-	Unit          v11.Unit `protobuf:"varint,3,opt,name=unit,proto3,enum=meshtrade.studio.instrument.v1.Unit" json:"unit,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Unit v11.Unit `protobuf:"varint,3,opt,name=unit,proto3,enum=meshtrade.studio.instrument.v1.Unit" json:"unit,omitempty"`
+	// Indicates if an ownership certifiate is avaialble for download for this asset balance.
+	OwnershipCertificateAvailable bool `protobuf:"varint,4,opt,name=ownership_certificate_available,json=ownershipCertificateAvailable,proto3" json:"ownership_certificate_available,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *InstrumentMetaData) Reset() {
@@ -314,6 +316,13 @@ func (x *InstrumentMetaData) GetUnit() v11.Unit {
 		return x.Unit
 	}
 	return v11.Unit(0)
+}
+
+func (x *InstrumentMetaData) GetOwnershipCertificateAvailable() bool {
+	if x != nil {
+		return x.OwnershipCertificateAvailable
+	}
+	return false
 }
 
 // Balance entry representing holdings of a specific financial instrument.
@@ -481,11 +490,12 @@ const file_meshtrade_wallet_account_v1_account_proto_rawDesc = "" +
 	"\x05state\x18\n" +
 	" \x01(\x0e2).meshtrade.wallet.account.v1.AccountStateR\x05state\x12@\n" +
 	"\bbalances\x18\v \x03(\v2$.meshtrade.wallet.account.v1.BalanceR\bbalances\x12H\n" +
-	"\vsignatories\x18\f \x03(\v2&.meshtrade.wallet.account.v1.SignatoryR\vsignatories\"\xa6\x01\n" +
+	"\vsignatories\x18\f \x03(\v2&.meshtrade.wallet.account.v1.SignatoryR\vsignatories\"\xee\x01\n" +
 	"\x12InstrumentMetaData\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12B\n" +
 	"\x04type\x18\x02 \x01(\x0e2..meshtrade.studio.instrument.v1.InstrumentTypeR\x04type\x128\n" +
-	"\x04unit\x18\x03 \x01(\x0e2$.meshtrade.studio.instrument.v1.UnitR\x04unit\"\xe4\x01\n" +
+	"\x04unit\x18\x03 \x01(\x0e2$.meshtrade.studio.instrument.v1.UnitR\x04unit\x12F\n" +
+	"\x1fownership_certificate_available\x18\x04 \x01(\bR\x1downershipCertificateAvailable\"\xe4\x01\n" +
 	"\aBalance\x121\n" +
 	"\x06amount\x18\x01 \x01(\v2\x19.meshtrade.type.v1.AmountR\x06amount\x12D\n" +
 	"\x10available_amount\x18\x02 \x01(\v2\x19.meshtrade.type.v1.AmountR\x0favailableAmount\x12`\n" +

--- a/proto/meshtrade/studio/instrument/v1/instrument_type.proto
+++ b/proto/meshtrade/studio/instrument/v1/instrument_type.proto
@@ -16,27 +16,27 @@ enum InstrumentType {
      This is a default value to prevent accidental assignment and should not be used.
   */
   INSTRUMENT_TYPE_UNSPECIFIED = 0;
-  
-  // Other or unlisted instrument type.
+  // Unknown/Uncategorised Instrument Type.
   INSTRUMENT_TYPE_OTHER = 1;
-  // Equity share.
+  // Equity Share.
   INSTRUMENT_TYPE_SHARE = 2;
-  // Preference share.
+  // Preference Share.
   INSTRUMENT_TYPE_PREFERENCE_SHARE = 3;
   // Bond.
   INSTRUMENT_TYPE_BOND = 4;
-  // Exchange-traded fund.
+  // Exchange Traded Fund
   INSTRUMENT_TYPE_ETF = 5;
-  // Exchange-traded note.
+  // Exchange Traded Note.
   INSTRUMENT_TYPE_ETN = 6;
-  // Actively managed certificate.
+  // Actively Managed Certificate.
   INSTRUMENT_TYPE_AMC = 7;
-  // Unit trust.
+  // Unit Trust.
   INSTRUMENT_TYPE_UNIT_TRUST = 8;
-  // Cryptocurrency.
+  // Cryptocurrency
   INSTRUMENT_TYPE_CRYPTO_CURRENCY = 9;
-  // Fiat currency.
+  // Fiat currency (non-blockchain ledgers)
   INSTRUMENT_TYPE_FIAT_CURRENCY = 10;
+  // 11 no longer used
   // Gold.
   INSTRUMENT_TYPE_GOLD = 12;
   // Silver.
@@ -57,24 +57,31 @@ enum InstrumentType {
   INSTRUMENT_TYPE_WHEAT = 20;
   // Soybeans.
   INSTRUMENT_TYPE_SOYBEANS = 21;
-  // Fiat-backed stablecoin.
-  INSTRUMENT_TYPE_FIAT_STABLECOIN = 22;
-  // Money market fund.
+  // 22 no longer used
+  // Blockchain Native Money market fund.
   INSTRUMENT_TYPE_MONEY_MARKET_FUND = 23;
-  // Tokenised money market fund.
+  // Tokenised Money market fund.
   INSTRUMENT_TYPE_MONEY_MARKET_FUND_STABLECOIN = 24;
   // Endowment wrapper.
   INSTRUMENT_TYPE_ENDOWMENT_WRAPPER = 25;
-  // Fund.
+  // Blockchain Native Fund.
   INSTRUMENT_TYPE_FUND = 26;
-  // Tokenised fund.
+  // Tokenised Fund.
   INSTRUMENT_TYPE_FUND_STABLECOIN = 27;
-  // Tokenised actively managed certificate.
+  // Tokenised AMC.
   INSTRUMENT_TYPE_AMC_STABLECOIN = 28;
   // Tokenised exchange-traded fund.
   INSTRUMENT_TYPE_ETF_STABLECOIN = 29;
   // Tokenised exchange-traded note.
   INSTRUMENT_TYPE_ETN_STABLECOIN = 30;
-  // Tokenised cryptocurrency.
+  // Wrapped cryptocurrency.
   INSTRUMENT_TYPE_CRYPTO_CURRENCY_STABLECOIN = 31;
+  // Stablecoin, i.e. tokenised fiat currency.
+  INSTRUMENT_TYPE_FIAT_CURRENCY_STABLECOIN = 32;
+  // Wrapped Cryptocurrency with yield.
+  INSTRUMENT_TYPE_YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN = 33;
+  // Fiat Currency Stablecoin with yield.
+  INSTRUMENT_TYPE_YIELD_BEARING_FIAT_CURRENCY_STABLECOIN = 34;
+  // Share in a liquidity pool share
+  INSTRUMENT_TYPE_LIQUIDITY_POOL_SHARE = 35;
 }

--- a/proto/meshtrade/wallet/account/v1/account.proto
+++ b/proto/meshtrade/wallet/account/v1/account.proto
@@ -166,6 +166,11 @@ message InstrumentMetaData {
      Examples: SHARE for equities, OUNCE for precious metals, NOTE for bonds.
   */
   meshtrade.studio.instrument.v1.Unit unit = 3;
+
+  /*
+     Indicates if an ownership certifiate is avaialble for download for this asset balance.
+  */
+  bool ownership_certificate_available = 4;
 }
 
 /*


### PR DESCRIPTION
## Summary
- **Extended `InstrumentType` enum** with new types: `FIAT_CURRENCY_STABLECOIN`, `YIELD_BEARING_CRYPTO_CURRENCY_STABLECOIN`, `YIELD_BEARING_FIAT_CURRENCY_STABLECOIN`, and `LIQUIDITY_POOL_SHARE`
- **Removed** deprecated `FIAT_STABLECOIN` (field 22) and reserved field 11, replacing with "no longer used" comments
- **Updated comments** across existing instrument types for consistency and clarity (e.g. distinguishing blockchain-native vs tokenised variants)
- **Added `ownership_certificate_available` field** to `InstrumentMetaData` in the wallet account proto

## Test plan
- [x] Verify `buf lint` passes on updated proto definitions
- [x] Run `./dev/tool.sh all` to regenerate all SDK bindings
- [x] Confirm generated Go code compiles and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)